### PR TITLE
Actualiza versión base de DemocracyOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM democracyos/democracyos:2.5.1
+FROM democracyos/democracyos:2.9.9
 
 MAINTAINER Matías Lescano <matias@democraciaenred.org>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   mongo:
     container_name: consultapublica-mongo
-    image: mongo
+    image: mongo:3.2
     ports:
       - 27017:27017
     volumes:

--- a/ext/lib/site/home-forum/component.js
+++ b/ext/lib/site/home-forum/component.js
@@ -27,7 +27,7 @@ export default class HomeForum extends Component {
           topicStore.findAll({ forum: forum.id })
         ])
       })
-      .then(([forum, topics]) => {
+      .then(([forum, [ topics, pagination ]]) => {
         this.setState({
           forum,
           topics

--- a/ext/lib/site/home-forum/topic-card/component.js
+++ b/ext/lib/site/home-forum/topic-card/component.js
@@ -15,7 +15,7 @@ export default ({ topic }) => (
     <div className='panel-body'>
       <h3>{topic.mediaTitle}</h3>
       <p className='text-muted'>
-        {`${topic.participants.length} ${t('proposal-article.participant.plural')}`}
+        {/* {`${topic.action.count} ${t('proposal-article.participant.plural')}`} */}
       </p>
     </div>
   </Link>

--- a/ext/package.json
+++ b/ext/package.json
@@ -12,6 +12,7 @@
     "lib/config": "lib/config/config"
   },
   "dependencies": {
-    "argob-poncho": "0.3.2"
+    "argob-poncho": "0.3.2",
+    "pug": "2.0.0-rc.4"
   }
 }


### PR DESCRIPTION
Actualiza la versión base a 2.9.9, esta versión modifica la manera en la que se guardan las votaciones de las publicaciones y elimina el conteo de participantes que incluía cantidad de usuarios que comentan más la cantidad de usuarios que votan a favor de un conteo de unicamente los usuarios que votan.
Como esta implementación no usa la funcionalidad de votos en las publicaciones, eliminé el conteo de votos temporalmente hasta que cree un conteo separado para comentarios.
Esta versión provocará que se ejecuten migraciones en la base de datos por lo que es recomendable hacer un backup de la base de datos.