### PR TITLE
Versión 3.0.8

### DIFF
--- a/ext/lib/admin/admin-edit-forum/component.js
+++ b/ext/lib/admin/admin-edit-forum/component.js
@@ -17,7 +17,8 @@ export default class EditForum extends Component {
         closingAt: this.props.forum.extra.closingAt,
         hidden: this.props.forum.extra.hidden,
         owner: this.props.forum.extra.owner,
-        ownerUrl: this.props.forum.extra.ownerUrl
+        ownerUrl: this.props.forum.extra.ownerUrl,
+        contentType: this.props.forum.extra.contentType || '',
       },
       coverUrl: this.props.forum.coverUrl,
       updated: false
@@ -99,7 +100,8 @@ export default class EditForum extends Component {
         hidden,
         owner,
         ownerUrl,
-        richSummary
+        richSummary,
+        contentType,
       }
     } = this.state
 
@@ -152,6 +154,16 @@ export default class EditForum extends Component {
                   maxLength='300'
                   value={summary}
                   onChange={this.handleChange('summary')} />
+              </div>
+            </fieldset>
+            <fieldset>
+              <label>{t('forum.form.contentType.label')}</label>
+              <div className='form-group clearfix contentType'>
+                <select value={contentType} onChange={this.handleChangeExtra('contentType')} placeholder="Elija una opcion">
+                  <option value="" disabled>- Elija una opción -</option>
+                  <option value="ejes">Ejes de consulta</option>
+                  <option value="propuestas">Propuestas</option>
+                </select>
               </div>
             </fieldset>
             <fieldset>

--- a/ext/lib/admin/admin-edit-forum/styles.styl
+++ b/ext/lib/admin/admin-edit-forum/styles.styl
@@ -2,7 +2,7 @@
   label.rich-summary
     float: none
 
-  input,
+  input, select,
   .input-group
     width 100%
 
@@ -36,3 +36,12 @@
       & + input
         border-top-left-radius 0
         border-bottom-left-radius 0
+  
+  select
+    height 42px
+    margin-top 0px
+    margin-bottom 0px
+    padding 8px 12px
+    border 1px solid #dedede
+    border-radius 3px
+    background-color white

--- a/ext/lib/site/home-forum/component.js
+++ b/ext/lib/site/home-forum/component.js
@@ -95,11 +95,20 @@ export default class HomeForum extends Component {
           <div className='jumbotron_body'>
             <div className='container'>
               <h1>{forum.title}</h1>
+              { forum.extra.contentType === 'ejes' &&
               <a
                 className='btn btn-primary'
                 onClick={this.handleScroll} >
                 Elegí un eje y participá
               </a>
+              }
+              { forum.extra.contentType === 'propuestas' && 
+                <a
+                  className='btn btn-primary'
+                  onClick={this.handleScroll} >
+                  Mirá las propuestas y participá
+                </a>
+              }
             </div>
           </div>
         </section>
@@ -123,8 +132,11 @@ export default class HomeForum extends Component {
           </div>
         }
         <div className='container topics-container' id='anchor' >
-          {this.state.topics.length > 0 &&
+          {this.state.topics.length > 0 && (forum.extra.contentType === 'ejes' || forum.extra.contentType === undefined) &&
             <h5>{`${this.state.topics.length} ${this.state.topics.length > 1 ? 'ejes comprenden' : 'eje comprende'} esta consulta`}</h5>
+          }
+          {this.state.topics.length > 0 && forum.extra.contentType === 'propuestas' &&
+            <h5>{`${this.state.topics.length} ${this.state.topics.length > 1 ? 'propuestas comprenden' : 'propuesta comprende'} esta consulta`}</h5>
           }
           <div className='topics-card-wrapper'>
             {this.state.topics

--- a/ext/lib/site/home-multiforum/forum-container/component.js
+++ b/ext/lib/site/home-multiforum/forum-container/component.js
@@ -6,7 +6,15 @@ export default ({ forum }) => (
   <div className='container forum-card-container'>
     <ForumCard forum={forum} />
     <div className='forum-slider-wrapper'>
-      <h4 className='forum-slider-title'>Los ejes que comprenden esta consulta son:</h4>
+      <h4 className='forum-slider-title'>{
+        forum.extra.contentType === 'ejes' && 'Los ejes '
+      }
+      {
+        forum.extra.contentType === undefined && 'Los ejes '
+      }
+      {
+        forum.extra.contentType === 'propuestas' && 'Las propuestas '        
+      }que comprenden esta consulta son:</h4>
       <CardsSlider forum={forum} />
     </div>
   </div>

--- a/ext/lib/site/home-multiforum/search/component.js
+++ b/ext/lib/site/home-multiforum/search/component.js
@@ -65,8 +65,11 @@ class Search extends React.Component {
           execSearch={this.execSearch}
           state={this.state}
         />
-        {showResults && <ResultsSearch results={results} term={term} />}
-        {showEmpty && 'No se han encontrado resultados'}
+        {showResults ? <ResultsSearch results={results} term={term} /> : null}
+        {showEmpty && <p style={{margin: '35px 0', textAlign: 'center'}}>
+        No se han encontrado resultados
+        </p>
+        }
       </div>
     )
   }

--- a/ext/lib/site/home-multiforum/search/results-search/component.js
+++ b/ext/lib/site/home-multiforum/search/results-search/component.js
@@ -57,7 +57,7 @@ const Consulta = ({ title, summary, img, createdAt, url }) => (
     <div className="third-column">
       <h5>{title}</h5>
       <p className="summary">{summary}</p>
-      <a href={url}>Ver los ejes que comprende la consulta</a>
+      <a href={url}>Ver los ejes/propuestas que comprende la consulta</a>
     </div>
   </div>
 )

--- a/ext/lib/site/home-multiforum/search/search-bar/component.js
+++ b/ext/lib/site/home-multiforum/search/search-bar/component.js
@@ -24,7 +24,7 @@ const SearchBar = ({
       </button>
     </div>
     <div
-      onMouseLeave={toggleAdvanceForm.bind(this, false)}
+      
       className={`advancedsearch ${state.show ? 'show': 'hide'}`}
     >
       <div className='button-link'>
@@ -50,7 +50,7 @@ const SearchBar = ({
             onChange={handleChange}
             checked={state.kind === 'eje'}
           />
-            Sólo ejes
+            Sólo ejes y propuestas
         </label>
         <label>
           <input

--- a/ext/lib/translations/lib/es.json
+++ b/ext/lib/translations/lib/es.json
@@ -33,6 +33,6 @@
   "comments.your-argument": "Tu comentario",
   "comments.your.arguments": "Tus comentarios",
   "proposal-options.must-be-signed-in": "Debés estar registrado para participar",
-
-  "forum.form.rich.summary.label": "Resumen largo"
+  "forum.form.rich.summary.label": "Resumen largo",
+  "forum.form.contentType.label": "Tipo de contenido"
 }


### PR DESCRIPTION
- Agregado el feature para marcar que tipo de contenido lleva la consulta. Al editar una comunidad, se puede elegir el tipo de contenido de la consulta. Solo existen dos opciones, **ejes de consulta.** y **propuestas**. Dependiendo de cual es el contenido cambian algunas etiquetas del sistema. Al crear una consulta (comunidad) siempre por defecto será el contenido como **ejes de consulta** pero se puede cambiar al editar la consulta (comunidad) de nuevo. Solamente ir al panel de administracion de la comunidad e ir a **Editar comunidad** 
- Arreglado el mensaje de "No se encuentran resultados" del buscador
- Arreglado un _mouseOver_ que ocultaba el buscador avanzado y era pesimo para la experiencia del usuario.

No hace falta ninguna migracion o cambio en la Base de datos con respecto a las consultas (comunidades)