### PR TITLE
Nuevo tipo de consulta: convocatoria; más cierre de consultas y otros cambios menores

### DIFF
--- a/ext/lib/admin/admin-topics-form/styles.styl
+++ b/ext/lib/admin/admin-topics-form/styles.styl
@@ -5,3 +5,6 @@
         
   .sugerencia
     margin-bottom: 30px
+    
+  .form-group.tag
+    display:none

--- a/ext/lib/admin/admin-topics-form/template-llamado.jade
+++ b/ext/lib/admin/admin-topics-form/template-llamado.jade
@@ -40,7 +40,7 @@
         .form-group
           label= '¿Cuál es tu propuesta?'
           textarea.form-control(name='body')= topic.body
-        .form-group
+        .form-group.tag
           label= 'Elegí la categoría asociada a tu propuesta'
           - if (te('admin-topics-form.description.tag'))
             span.help-text= t('admin-topics-form.description.tag')


### PR DESCRIPTION
### Actualizaciones

**Convocatorias**
- Agregado nuevo tipo de consulta: convocatoria.
- Agregado campo "Sugerencia para usuarios" en edición de convocatorias. Este texto aparecerá en el formulario de carga de propuestas ciudadanas, debajo del título, a modo de instrucciones para el usuario.
- Nuevo formulario de carga de propuestas ciudadanas (solo dentro de convocatorias).


**Cierre de consultas**
- Agregado campos "Palabras de cierre" y "Link de cierre" en todas las consultas. Se mostrarán cuando se pase la fecha de cierre de la consulta. En el caso de convocatorias este campo determina la fecha de cierre de las propuestas ciudadanas que se hayan cargado, así como la imposibilidad de cargar nuevas o comentarar/apoyar existentes. En el resto de las consultas (ejes o propuestas) cada eje o propuesta dentro de la misma tiene su propia fecha de cierre, respetando como funcionaba la plataforma anteriormente.

**Otros**
- Corregido algunos textos y links en el proceso de verificación de cuentas.
- Corregida la posibilidad de pedir verificación de cuenta varias veces.
- Correciónes sobre íconos de redes sociales, tanto es su disposición (a veces aparecían en lugares incorrectos) como en su interacción (a veces al hacerles click no funcionaban como esperado)
